### PR TITLE
adds isAbsolute

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,27 @@
+# Test against this version of Node.js
+environment:
+  matrix:
+    # node.js
+    - nodejs_version: "6.0"
+    - nodejs_version: "5.0"
+    - nodejs_version: "4.0"
+    - nodejs_version: "0.12"
+    - nodejs_version: "0.10"
+
+# Install scripts. (runs after repo cloning)
+install:
+  # Get the latest stable version of Node.js or io.js
+  - ps: Install-Product node $env:nodejs_version
+  # install modules
+  - npm install
+
+# Post-install test scripts.
+test_script:
+  # Output useful info for debugging.
+  - node --version
+  - npm --version
+  # run tests
+  - npm test
+
+# Don't actually build.
+build: off

--- a/index.js
+++ b/index.js
@@ -3,26 +3,39 @@
 var path = require('path');
 var extend = require('extend-shallow');
 var isNegated = require('is-negated-glob');
+var isAbsolute = require('is-absolute');
 
 module.exports = function(glob, options) {
+  // shallow clone options
   var opts = extend({}, options);
-  opts.cwd = opts.cwd ? path.resolve(opts.cwd) : process.cwd();
+  // ensure cwd is absolute
+  var cwd = path.resolve(opts.cwd ? opts.cwd : process.cwd());
+
+  var rootDir = opts.root;
+  // if `options.root` is defined, ensure it's absolute
+  if (rootDir && !isAbsolute(opts.root)) {
+    rootDir = path.resolve(rootDir);
+  }
 
   // store last character before glob is modified
   var suffix = glob.slice(-1);
 
+  // check to see if glob is negated (and not a leading negated-extglob)
   var ing = isNegated(glob);
   glob = ing.pattern;
 
-  if (opts.root && glob.charAt(0) === '/') {
-    glob = path.join(path.resolve(opts.root), '.' + glob);
-  } else {
-    glob = path.resolve(opts.cwd, glob);
+  // make glob absolute
+  if (rootDir && glob.charAt(0) === '/') {
+    glob = path.join(rootDir, glob);
+  } else if (!isAbsolute(glob)) {
+    glob = path.resolve(cwd, glob);
   }
 
+  // if glob had a trailing `/`, re-add it now in case it was removed
   if (suffix === '/' && glob.slice(-1) !== '/') {
     glob += '/';
   }
 
+  // re-add leading `!` if it was removed
   return ing.negated ? '!' + glob : glob;
 };

--- a/index.js
+++ b/index.js
@@ -26,6 +26,10 @@ module.exports = function(glob, options) {
     glob = glob.slice(2);
   }
 
+  if (glob.slice(0, 1) === '.') {
+    glob = glob.slice(1);
+  }
+
   // store last character before glob is modified
   var suffix = glob.slice(-1);
 
@@ -60,5 +64,6 @@ function join(dir, glob) {
   if (glob.charAt(0) === '/') {
     glob = glob.slice(1);
   }
+  if (!glob) return dir;
   return dir + '/' + glob;
 }

--- a/index.js
+++ b/index.js
@@ -22,6 +22,10 @@ module.exports = function(glob, options) {
     }
   }
 
+  if (glob.slice(0, 2) === './') {
+    glob = glob.slice(2);
+  }
+
   // store last character before glob is modified
   var suffix = glob.slice(-1);
 
@@ -50,9 +54,6 @@ function unixify(filepath) {
 }
 
 function join(dir, glob) {
-  if (!dir) return glob;
-  if (!glob) return dir;
-
   if (dir.charAt(dir.length - 1) === '/') {
     dir = dir.slice(0, -1);
   }

--- a/index.js
+++ b/index.js
@@ -22,12 +22,14 @@ module.exports = function(glob, options) {
     }
   }
 
+  // trim starting ./ from glob patterns
   if (glob.slice(0, 2) === './') {
     glob = glob.slice(2);
   }
 
-  if (glob.slice(0, 1) === '.') {
-    glob = glob.slice(1);
+  // when the glob pattern is only a . use an empty string
+  if (glob.length === 1 && glob === '.') {
+    glob = '';
   }
 
   // store last character before glob is modified

--- a/index.js
+++ b/index.js
@@ -16,10 +16,10 @@ module.exports = function(glob, options) {
   var rootDir = opts.root;
   // if `options.root` is defined, ensure it's absolute
   if (rootDir) {
-    if (process.platform === 'win32' || !isAbsolute(rootDir)) {
-      rootDir = path.resolve(rootDir);
-    }
     rootDir = unixify(rootDir);
+    if (process.platform === 'win32' || !isAbsolute(rootDir)) {
+      rootDir = unixify(path.resolve(rootDir));
+    }
   }
 
   // store last character before glob is modified

--- a/index.js
+++ b/index.js
@@ -42,7 +42,7 @@ module.exports = function(glob, options) {
   // make glob absolute
   if (rootDir && glob.charAt(0) === '/') {
     glob = join(rootDir, glob);
-  } else if (process.platform === 'win32' || !isAbsolute(glob)) {
+  } else if (!isAbsolute(glob)) {
     glob = join(cwd, glob);
   }
 

--- a/index.js
+++ b/index.js
@@ -11,17 +11,15 @@ module.exports = function(glob, options) {
 
   // ensure cwd is absolute
   var cwd = path.resolve(opts.cwd ? opts.cwd : process.cwd());
-  if (process.platform === 'win32' || opts.unixify === true) {
-    cwd = unixify(cwd);
-  }
+  cwd = unixify(cwd);
 
   var rootDir = opts.root;
   // if `options.root` is defined, ensure it's absolute
-  if (rootDir && (process.platform === 'win32' || !isAbsolute(opts.root))) {
-    rootDir = path.resolve(rootDir);
-    if (process.platform === 'win32' || opts.unixify === true) {
-      rootDir = unixify(rootDir);
+  if (rootDir) {
+    if (process.platform === 'win32' || !isAbsolute(rootDir)) {
+      rootDir = path.resolve(rootDir);
     }
+    rootDir = unixify(rootDir);
   }
 
   // store last character before glob is modified
@@ -33,9 +31,9 @@ module.exports = function(glob, options) {
 
   // make glob absolute
   if (rootDir && glob.charAt(0) === '/') {
-    glob = path.join(rootDir, glob);
+    glob = join(rootDir, glob);
   } else if (process.platform === 'win32' || !isAbsolute(glob)) {
-    glob = path.resolve(cwd, glob);
+    glob = join(cwd, glob);
   }
 
   // if glob had a trailing `/`, re-add it now in case it was removed
@@ -49,4 +47,17 @@ module.exports = function(glob, options) {
 
 function unixify(filepath) {
   return filepath.replace(/\\/g, '/');
+}
+
+function join(dir, glob) {
+  if (!dir) return glob;
+  if (!glob) return dir;
+
+  if (dir.charAt(dir.length - 1) === '/') {
+    dir = dir.slice(0, -1);
+  }
+  if (glob.charAt(0) === '/') {
+    glob = glob.slice(1);
+  }
+  return dir + '/' + glob;
 }

--- a/index.js
+++ b/index.js
@@ -42,7 +42,7 @@ module.exports = function(glob, options) {
   // make glob absolute
   if (rootDir && glob.charAt(0) === '/') {
     glob = join(rootDir, glob);
-  } else if (!isAbsolute(glob)) {
+  } else if (!isAbsolute(glob) || glob.slice(0, 2) === '\\\\') {
     glob = join(cwd, glob);
   }
 

--- a/index.js
+++ b/index.js
@@ -8,12 +8,19 @@ var isAbsolute = require('is-absolute');
 module.exports = function(glob, options) {
   // shallow clone options
   var opts = extend({}, options);
+
   // ensure cwd is absolute
   var cwd = path.resolve(opts.cwd ? opts.cwd : process.cwd());
+  if (process.platform === 'win32' || opts.unixify === true) {
+    cwd = unixify(cwd);
+  }
 
   var rootDir = opts.root;
   // if `options.root` is defined, ensure it's absolute
   if (rootDir && !isAbsolute(opts.root)) {
+    if (process.platform === 'win32' || opts.unixify === true) {
+      rootDir = unixify(rootDir);
+    }
     rootDir = path.resolve(rootDir);
   }
 
@@ -39,3 +46,7 @@ module.exports = function(glob, options) {
   // re-add leading `!` if it was removed
   return ing.negated ? '!' + glob : glob;
 };
+
+function unixify(filepath) {
+  return filepath.replace(/\\/g, '/');
+}

--- a/index.js
+++ b/index.js
@@ -42,7 +42,7 @@ module.exports = function(glob, options) {
   // make glob absolute
   if (rootDir && glob.charAt(0) === '/') {
     glob = join(rootDir, glob);
-  } else if (!isAbsolute(glob) || glob.slice(0, 2) === '\\\\') {
+  } else if (!isAbsolute(glob) || glob.slice(0, 1) === '\\') {
     glob = join(cwd, glob);
   }
 

--- a/index.js
+++ b/index.js
@@ -17,11 +17,11 @@ module.exports = function(glob, options) {
 
   var rootDir = opts.root;
   // if `options.root` is defined, ensure it's absolute
-  if (rootDir && !isAbsolute(opts.root)) {
+  if (rootDir && (process.platform === 'win32' || !isAbsolute(opts.root))) {
+    rootDir = path.resolve(rootDir);
     if (process.platform === 'win32' || opts.unixify === true) {
       rootDir = unixify(rootDir);
     }
-    rootDir = path.resolve(rootDir);
   }
 
   // store last character before glob is modified
@@ -34,7 +34,7 @@ module.exports = function(glob, options) {
   // make glob absolute
   if (rootDir && glob.charAt(0) === '/') {
     glob = path.join(rootDir, glob);
-  } else if (!isAbsolute(glob)) {
+  } else if (process.platform === 'win32' || !isAbsolute(glob)) {
     glob = path.resolve(cwd, glob);
   }
 

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   },
   "dependencies": {
     "extend-shallow": "^2.0.1",
+    "is-absolute": "^0.2.5",
     "is-negated-glob": "^1.0.0"
   },
   "devDependencies": {

--- a/test.js
+++ b/test.js
@@ -4,72 +4,93 @@ require('mocha');
 var path = require('path');
 var assert = require('assert');
 var resolve = require('./');
-var actual, fixture;
+var sep = path.sep;
+var fixture;
+var actual;
 
 describe('resolve', function () {
-  it('should make a path absolute', function () {
-    assert.equal(resolve('a'), path.resolve('a'));
+  describe('posix', function () {
+    it('should make a path absolute', function () {
+      assert.equal(resolve('a'), path.resolve('a'));
+    });
+
+    it('should make a glob absolute', function () {
+      assert.equal(resolve('a/*.js'), path.resolve('a/*.js'));
+    });
+
+    it('should retain trailing slashes', function () {
+      actual = resolve('a/*/');
+      assert.equal(actual, path.resolve('a/*') + '/');
+      assert.equal(actual.slice(-1), '/');
+    });
+
+    it('should retain trailing slashes with cwd', function () {
+      fixture = './fixtures/whatsgoingon/*/';
+      actual = resolve(fixture, {cwd: __dirname});
+      assert.equal(actual, path.resolve(fixture) + '/');
+      assert.equal(actual.slice(-1), '/');
+    });
+
+    it('should make a negative glob absolute', function () {
+      actual = resolve('!a/*.js');
+      assert.equal(actual, '!' + path.resolve('a/*.js'));
+    });
+
+    it('should make a negative extglob absolute', function () {
+      actual = resolve('!(foo)');
+      assert.equal(actual, path.resolve('!(foo)'));
+    });
+
+    it('should make an escaped negative extglob absolute', function () {
+      actual = resolve('\\!(foo)');
+      assert.equal(actual, path.resolve('\\!(foo)'));
+    });
+
+    it('should make a glob absolute from a cwd', function () {
+      actual = resolve('a/*.js', {cwd: 'foo'});
+      assert.equal(actual, path.resolve('foo/a/*.js'));
+    });
+
+    it('should make a negative glob absolute from a cwd', function () {
+      actual = resolve('!a/*.js', {cwd: 'foo'});
+      assert.equal(actual, '!' + path.resolve('foo/a/*.js'));
+    });
+
+    it('should make a glob absolute from a root path', function () {
+      actual = resolve('/a/*.js', {root: 'foo'});
+      assert.equal(actual, path.resolve('foo/a/*.js'));
+    });
+
+    it('should make a glob absolute from a root slash', function () {
+      actual = resolve('/a/*.js', {root: '/'});
+      assert.equal(actual, path.resolve('/a/*.js'));
+    });
+
+    it('should make a glob absolute from a negative root path', function () {
+      actual = resolve('!/a/*.js', {root: 'foo'});
+      assert.equal(actual, '!' + path.resolve('foo/a/*.js'));
+    });
+
+    it('should make a negative glob absolute from a negative root path', function () {
+      actual = resolve('!/a/*.js', {root: '/'})
+      assert.equal(actual, '!' + path.resolve('/a/*.js'));
+    });
   });
 
-  it('should make a glob absolute', function () {
-    assert.equal(resolve('a/*.js'), path.resolve('a/*.js'));
-  });
+  describe('windows', function () {
+    it('should make an escaped negative extglob absolute', function () {
+      actual = resolve('foo/bar\\!(baz)', {unixify: true});
+      assert.equal(actual, path.resolve('foo/bar\\!(baz)'));
+    });
 
-  it('should retain trailing slashes', function () {
-    actual = resolve('a/*/');
-    assert.equal(actual, path.resolve('a/*') + '/');
-    assert.equal(actual.slice(-1), '/');
-  });
+    it('should make a glob absolute from a root path', function () {
+      actual = resolve('/a/*.js', {root: 'foo\\bar\\baz', unixify: true});
+      assert.equal(actual, path.resolve('foo/bar/baz/a/*.js'));
+    });
 
-  it('should retain trailing slashes with cwd', function () {
-    fixture = './fixtures/whatsgoingon/*/';
-    actual = resolve(fixture, {cwd: __dirname});
-    assert.equal(actual, path.resolve(fixture) + '/');
-    assert.equal(actual.slice(-1), '/');
-  });
-
-  it('should make a negative glob absolute', function () {
-    actual = resolve('!a/*.js');
-    assert.equal(actual, '!' + path.resolve('a/*.js'));
-  });
-
-  it('should make a negative extglob absolute', function () {
-    actual = resolve('!(foo)');
-    assert.equal(actual, path.resolve('!(foo)'));
-  });
-
-  it('should make an escaped negative extglob absolute', function () {
-    actual = resolve('\\!(foo)');
-    assert.equal(actual, path.resolve('\\!(foo)'));
-  });
-
-  it('should make a glob absolute from a cwd', function () {
-    actual = resolve('a/*.js', {cwd: 'foo'});
-    assert.equal(actual, path.resolve('foo/a/*.js'));
-  });
-
-  it('should make a negative glob absolute from a cwd', function () {
-    actual = resolve('!a/*.js', {cwd: 'foo'});
-    assert.equal(actual, '!' + path.resolve('foo/a/*.js'));
-  });
-
-  it('should make a glob absolute from a root path', function () {
-    actual = resolve('/a/*.js', {root: 'foo'});
-    assert.equal(actual, path.resolve('foo/a/*.js'));
-  });
-
-  it('should make a glob absolute from a root slash', function () {
-    actual = resolve('/a/*.js', {root: '/'});
-    assert.equal(actual, path.resolve('/a/*.js'));
-  });
-
-  it('should make a glob absolute from a negative root path', function () {
-    actual = resolve('!/a/*.js', {root: 'foo'});
-    assert.equal(actual, '!' + path.resolve('foo/a/*.js'));
-  });
-
-  it('should make a negative glob absolute from a negative root path', function () {
-    actual = resolve('!/a/*.js', {root: '/'})
-    assert.equal(actual, '!' + path.resolve('/a/*.js'));
+    it('should make a glob absolute from a root slash', function () {
+      actual = resolve('/a/*.js', {root: '\\\\', unixify: true});
+      assert.equal(actual, path.resolve('/a/*.js'));
+    });
   });
 });

--- a/test.js
+++ b/test.js
@@ -35,6 +35,13 @@ describe('resolve', function () {
       assert.equal(actual.slice(-1), '/');
     });
 
+    it.skip('should handle dots in glob?', function () {
+      fixture = './fixtures/whatsgoingon/*/';
+      actual = resolve(fixture, {cwd: __dirname});
+      assert.equal(actual, unixify(path.resolve(fixture)) + '/');
+      assert.equal(actual.slice(-1), '/');
+    });
+
     it('should make a negative glob absolute', function () {
       actual = resolve('!a/*.js');
       assert.equal(actual, '!' + unixify(path.resolve('a/*.js')));
@@ -83,17 +90,17 @@ describe('resolve', function () {
 
   describe('windows', function () {
     it('should make an escaped negative extglob absolute', function () {
-      actual = resolve('foo/bar\\!(baz)', {unixify: true});
+      actual = resolve('foo/bar\\!(baz)');
       assert.equal(actual, unixify(path.resolve('foo/bar')) + '\\!(baz)');
     });
 
     it('should make a glob absolute from a root path', function () {
-      actual = resolve('/a/*.js', {root: 'foo\\bar\\baz', unixify: true});
+      actual = resolve('/a/*.js', {root: 'foo\\bar\\baz'});
       assert.equal(actual, unixify(path.resolve('foo/bar/baz/a/*.js')));
     });
 
     it('should make a glob absolute from a root slash', function () {
-      actual = resolve('/a/*.js', {root: '\\\\', unixify: true});
+      actual = resolve('/a/*.js', {root: '\\'});
       assert.equal(actual, unixify(path.resolve('/a/*.js')));
     });
   });

--- a/test.js
+++ b/test.js
@@ -35,11 +35,10 @@ describe('resolve', function () {
       assert.equal(actual.slice(-1), '/');
     });
 
-    it.skip('should handle dots in glob?', function () {
+    it('should handle ./ at the beginnnig of a glob', function () {
       fixture = './fixtures/whatsgoingon/*/';
       actual = resolve(fixture, {cwd: __dirname});
       assert.equal(actual, unixify(path.resolve(fixture)) + '/');
-      assert.equal(actual.slice(-1), '/');
     });
 
     it('should make a negative glob absolute', function () {

--- a/test.js
+++ b/test.js
@@ -8,89 +8,93 @@ var sep = path.sep;
 var fixture;
 var actual;
 
+function unixify(filepath) {
+  return filepath.replace(/\\/g, '/');
+}
+
 describe('resolve', function () {
   describe('posix', function () {
     it('should make a path absolute', function () {
-      assert.equal(resolve('a'), path.resolve('a'));
+      assert.equal(resolve('a'), unixify(path.resolve('a')));
     });
 
     it('should make a glob absolute', function () {
-      assert.equal(resolve('a/*.js'), path.resolve('a/*.js'));
+      assert.equal(resolve('a/*.js'), unixify(path.resolve('a/*.js')));
     });
 
     it('should retain trailing slashes', function () {
       actual = resolve('a/*/');
-      assert.equal(actual, path.resolve('a/*') + '/');
+      assert.equal(actual, unixify(path.resolve('a/*')) + '/');
       assert.equal(actual.slice(-1), '/');
     });
 
     it('should retain trailing slashes with cwd', function () {
-      fixture = './fixtures/whatsgoingon/*/';
+      fixture = 'fixtures/whatsgoingon/*/';
       actual = resolve(fixture, {cwd: __dirname});
-      assert.equal(actual, path.resolve(fixture) + '/');
+      assert.equal(actual, unixify(path.resolve(fixture)) + '/');
       assert.equal(actual.slice(-1), '/');
     });
 
     it('should make a negative glob absolute', function () {
       actual = resolve('!a/*.js');
-      assert.equal(actual, '!' + path.resolve('a/*.js'));
+      assert.equal(actual, '!' + unixify(path.resolve('a/*.js')));
     });
 
     it('should make a negative extglob absolute', function () {
       actual = resolve('!(foo)');
-      assert.equal(actual, path.resolve('!(foo)'));
+      assert.equal(actual, unixify(path.resolve('!(foo)')));
     });
 
     it('should make an escaped negative extglob absolute', function () {
       actual = resolve('\\!(foo)');
-      assert.equal(actual, path.resolve('\\!(foo)'));
+      assert.equal(actual, unixify(path.resolve('.')) + '/\\!(foo)');
     });
 
     it('should make a glob absolute from a cwd', function () {
       actual = resolve('a/*.js', {cwd: 'foo'});
-      assert.equal(actual, path.resolve('foo/a/*.js'));
+      assert.equal(actual, unixify(path.resolve('foo/a/*.js')));
     });
 
     it('should make a negative glob absolute from a cwd', function () {
       actual = resolve('!a/*.js', {cwd: 'foo'});
-      assert.equal(actual, '!' + path.resolve('foo/a/*.js'));
+      assert.equal(actual, '!' + unixify(path.resolve('foo/a/*.js')));
     });
 
     it('should make a glob absolute from a root path', function () {
       actual = resolve('/a/*.js', {root: 'foo'});
-      assert.equal(actual, path.resolve('foo/a/*.js'));
+      assert.equal(actual, unixify(path.resolve('foo/a/*.js')));
     });
 
     it('should make a glob absolute from a root slash', function () {
       actual = resolve('/a/*.js', {root: '/'});
-      assert.equal(actual, path.resolve('/a/*.js'));
+      assert.equal(actual, unixify(path.resolve('/a/*.js')));
     });
 
     it('should make a glob absolute from a negative root path', function () {
       actual = resolve('!/a/*.js', {root: 'foo'});
-      assert.equal(actual, '!' + path.resolve('foo/a/*.js'));
+      assert.equal(actual, '!' + unixify(path.resolve('foo/a/*.js')));
     });
 
     it('should make a negative glob absolute from a negative root path', function () {
       actual = resolve('!/a/*.js', {root: '/'})
-      assert.equal(actual, '!' + path.resolve('/a/*.js'));
+      assert.equal(actual, '!' + unixify(path.resolve('/a/*.js')));
     });
   });
 
   describe('windows', function () {
     it('should make an escaped negative extglob absolute', function () {
       actual = resolve('foo/bar\\!(baz)', {unixify: true});
-      assert.equal(actual, path.resolve('foo/bar\\!(baz)'));
+      assert.equal(actual, unixify(path.resolve('foo/bar')) + '\\!(baz)');
     });
 
     it('should make a glob absolute from a root path', function () {
       actual = resolve('/a/*.js', {root: 'foo\\bar\\baz', unixify: true});
-      assert.equal(actual, path.resolve('foo/bar/baz/a/*.js'));
+      assert.equal(actual, unixify(path.resolve('foo/bar/baz/a/*.js')));
     });
 
     it('should make a glob absolute from a root slash', function () {
       actual = resolve('/a/*.js', {root: '\\\\', unixify: true});
-      assert.equal(actual, path.resolve('/a/*.js'));
+      assert.equal(actual, unixify(path.resolve('/a/*.js')));
     });
   });
 });


### PR DESCRIPTION
this pr adds isAbsolute to ensure that globs are absolute. (TODO: I haven't had a chance to get appveyor running, will do that next along with windows tests. I just wanted to push this up to start discussing).

**slashes**

I spent quite a bit of time exploring different approaches to normalizing slashes, but I arrived at the conclusion that it's not a good idea - probably for the same reasons that node-glob disallows backslashes as path separators in globs.

**escaping**

Since most glob characters are perfectly valid path characters when used in normal file paths, there are too many scenarios where backslashes would indicate escaping, and not path separators. 

If we muddy the waters on this, we will never be 100% correct, and users won't have a surefire way to tell us that they're escaping a character.

On that same point, I believe the main place where it really matters is if a path has a leading slash (since we need to know if it's absolute or not). But in windows, an absolute path shouldn't being with a slash or backslash, it would begin with a drive letter. Hopefully [this check](https://github.com/jonschlinkert/to-absolute-glob/compare/is-absolute?expand=1#diff-168726dbe96b3ce427e7fedce31bb0bcR30) resolves any issues you were having regarding absolute paths with windows.

(also, fwiw in node-glob, most of the usage of `makeAbs` is on actual file paths I believe. I only saw one place where it seems to be used on globs. IMHO - if there is no good reason to do that in glob-stream, I'd leave it to node-glob)

cc @phated
