### PR TITLE
Updates for discussion

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,27 @@
+# Test against this version of Node.js
+environment:
+  matrix:
+    # node.js
+    - nodejs_version: "6.0"
+    - nodejs_version: "5.0"
+    - nodejs_version: "4.0"
+    - nodejs_version: "0.12"
+    - nodejs_version: "0.10"
+
+# Install scripts. (runs after repo cloning)
+install:
+  # Get the latest stable version of Node.js or io.js
+  - ps: Install-Product node $env:nodejs_version
+  # install modules
+  - npm install
+
+# Post-install test scripts.
+test_script:
+  # Output useful info for debugging.
+  - node --version
+  - npm --version
+  # run tests
+  - npm test
+
+# Don't actually build.
+build: off

--- a/index.js
+++ b/index.js
@@ -26,6 +26,10 @@ module.exports = function(glob, options) {
     glob = glob.slice(2);
   }
 
+  if (glob.slice(0, 1) === '.') {
+    glob = glob.slice(1);
+  }
+
   // store last character before glob is modified
   var suffix = glob.slice(-1);
 
@@ -60,5 +64,6 @@ function join(dir, glob) {
   if (glob.charAt(0) === '/') {
     glob = glob.slice(1);
   }
+  if (!glob) return dir;
   return dir + '/' + glob;
 }

--- a/index.js
+++ b/index.js
@@ -22,6 +22,10 @@ module.exports = function(glob, options) {
     }
   }
 
+  if (glob.slice(0, 2) === './') {
+    glob = glob.slice(2);
+  }
+
   // store last character before glob is modified
   var suffix = glob.slice(-1);
 
@@ -50,9 +54,6 @@ function unixify(filepath) {
 }
 
 function join(dir, glob) {
-  if (!dir) return glob;
-  if (!glob) return dir;
-
   if (dir.charAt(dir.length - 1) === '/') {
     dir = dir.slice(0, -1);
   }

--- a/index.js
+++ b/index.js
@@ -22,12 +22,14 @@ module.exports = function(glob, options) {
     }
   }
 
+  // trim starting ./ from glob patterns
   if (glob.slice(0, 2) === './') {
     glob = glob.slice(2);
   }
 
-  if (glob.slice(0, 1) === '.') {
-    glob = glob.slice(1);
+  // when the glob pattern is only a . use an empty string
+  if (glob.length === 1 && glob === '.') {
+    glob = '';
   }
 
   // store last character before glob is modified

--- a/index.js
+++ b/index.js
@@ -16,10 +16,10 @@ module.exports = function(glob, options) {
   var rootDir = opts.root;
   // if `options.root` is defined, ensure it's absolute
   if (rootDir) {
-    if (process.platform === 'win32' || !isAbsolute(rootDir)) {
-      rootDir = path.resolve(rootDir);
-    }
     rootDir = unixify(rootDir);
+    if (process.platform === 'win32' || !isAbsolute(rootDir)) {
+      rootDir = unixify(path.resolve(rootDir));
+    }
   }
 
   // store last character before glob is modified

--- a/index.js
+++ b/index.js
@@ -42,7 +42,7 @@ module.exports = function(glob, options) {
   // make glob absolute
   if (rootDir && glob.charAt(0) === '/') {
     glob = join(rootDir, glob);
-  } else if (process.platform === 'win32' || !isAbsolute(glob)) {
+  } else if (!isAbsolute(glob)) {
     glob = join(cwd, glob);
   }
 

--- a/index.js
+++ b/index.js
@@ -11,17 +11,15 @@ module.exports = function(glob, options) {
 
   // ensure cwd is absolute
   var cwd = path.resolve(opts.cwd ? opts.cwd : process.cwd());
-  if (process.platform === 'win32' || opts.unixify === true) {
-    cwd = unixify(cwd);
-  }
+  cwd = unixify(cwd);
 
   var rootDir = opts.root;
   // if `options.root` is defined, ensure it's absolute
-  if (rootDir && (process.platform === 'win32' || !isAbsolute(opts.root))) {
-    rootDir = path.resolve(rootDir);
-    if (process.platform === 'win32' || opts.unixify === true) {
-      rootDir = unixify(rootDir);
+  if (rootDir) {
+    if (process.platform === 'win32' || !isAbsolute(rootDir)) {
+      rootDir = path.resolve(rootDir);
     }
+    rootDir = unixify(rootDir);
   }
 
   // store last character before glob is modified
@@ -33,9 +31,9 @@ module.exports = function(glob, options) {
 
   // make glob absolute
   if (rootDir && glob.charAt(0) === '/') {
-    glob = path.join(rootDir, glob);
+    glob = join(rootDir, glob);
   } else if (process.platform === 'win32' || !isAbsolute(glob)) {
-    glob = path.resolve(cwd, glob);
+    glob = join(cwd, glob);
   }
 
   // if glob had a trailing `/`, re-add it now in case it was removed
@@ -49,4 +47,17 @@ module.exports = function(glob, options) {
 
 function unixify(filepath) {
   return filepath.replace(/\\/g, '/');
+}
+
+function join(dir, glob) {
+  if (!dir) return glob;
+  if (!glob) return dir;
+
+  if (dir.charAt(dir.length - 1) === '/') {
+    dir = dir.slice(0, -1);
+  }
+  if (glob.charAt(0) === '/') {
+    glob = glob.slice(1);
+  }
+  return dir + '/' + glob;
 }

--- a/index.js
+++ b/index.js
@@ -42,7 +42,7 @@ module.exports = function(glob, options) {
   // make glob absolute
   if (rootDir && glob.charAt(0) === '/') {
     glob = join(rootDir, glob);
-  } else if (!isAbsolute(glob)) {
+  } else if (!isAbsolute(glob) || glob.slice(0, 2) === '\\\\') {
     glob = join(cwd, glob);
   }
 

--- a/index.js
+++ b/index.js
@@ -42,7 +42,7 @@ module.exports = function(glob, options) {
   // make glob absolute
   if (rootDir && glob.charAt(0) === '/') {
     glob = join(rootDir, glob);
-  } else if (!isAbsolute(glob) || glob.slice(0, 2) === '\\\\') {
+  } else if (!isAbsolute(glob) || glob.slice(0, 1) === '\\') {
     glob = join(cwd, glob);
   }
 

--- a/index.js
+++ b/index.js
@@ -17,11 +17,11 @@ module.exports = function(glob, options) {
 
   var rootDir = opts.root;
   // if `options.root` is defined, ensure it's absolute
-  if (rootDir && !isAbsolute(opts.root)) {
+  if (rootDir && (process.platform === 'win32' || !isAbsolute(opts.root))) {
+    rootDir = path.resolve(rootDir);
     if (process.platform === 'win32' || opts.unixify === true) {
       rootDir = unixify(rootDir);
     }
-    rootDir = path.resolve(rootDir);
   }
 
   // store last character before glob is modified
@@ -34,7 +34,7 @@ module.exports = function(glob, options) {
   // make glob absolute
   if (rootDir && glob.charAt(0) === '/') {
     glob = path.join(rootDir, glob);
-  } else if (!isAbsolute(glob)) {
+  } else if (process.platform === 'win32' || !isAbsolute(glob)) {
     glob = path.resolve(cwd, glob);
   }
 

--- a/test.js
+++ b/test.js
@@ -35,6 +35,13 @@ describe('resolve', function () {
       assert.equal(actual.slice(-1), '/');
     });
 
+    it.skip('should handle dots in glob?', function () {
+      fixture = './fixtures/whatsgoingon/*/';
+      actual = resolve(fixture, {cwd: __dirname});
+      assert.equal(actual, unixify(path.resolve(fixture)) + '/');
+      assert.equal(actual.slice(-1), '/');
+    });
+
     it('should make a negative glob absolute', function () {
       actual = resolve('!a/*.js');
       assert.equal(actual, '!' + unixify(path.resolve('a/*.js')));
@@ -83,17 +90,17 @@ describe('resolve', function () {
 
   describe('windows', function () {
     it('should make an escaped negative extglob absolute', function () {
-      actual = resolve('foo/bar\\!(baz)', {unixify: true});
+      actual = resolve('foo/bar\\!(baz)');
       assert.equal(actual, unixify(path.resolve('foo/bar')) + '\\!(baz)');
     });
 
     it('should make a glob absolute from a root path', function () {
-      actual = resolve('/a/*.js', {root: 'foo\\bar\\baz', unixify: true});
+      actual = resolve('/a/*.js', {root: 'foo\\bar\\baz'});
       assert.equal(actual, unixify(path.resolve('foo/bar/baz/a/*.js')));
     });
 
     it('should make a glob absolute from a root slash', function () {
-      actual = resolve('/a/*.js', {root: '\\\\', unixify: true});
+      actual = resolve('/a/*.js', {root: '\\'});
       assert.equal(actual, unixify(path.resolve('/a/*.js')));
     });
   });

--- a/test.js
+++ b/test.js
@@ -35,11 +35,10 @@ describe('resolve', function () {
       assert.equal(actual.slice(-1), '/');
     });
 
-    it.skip('should handle dots in glob?', function () {
+    it('should handle ./ at the beginnnig of a glob', function () {
       fixture = './fixtures/whatsgoingon/*/';
       actual = resolve(fixture, {cwd: __dirname});
       assert.equal(actual, unixify(path.resolve(fixture)) + '/');
-      assert.equal(actual.slice(-1), '/');
     });
 
     it('should make a negative glob absolute', function () {

--- a/test.js
+++ b/test.js
@@ -8,89 +8,93 @@ var sep = path.sep;
 var fixture;
 var actual;
 
+function unixify(filepath) {
+  return filepath.replace(/\\/g, '/');
+}
+
 describe('resolve', function () {
   describe('posix', function () {
     it('should make a path absolute', function () {
-      assert.equal(resolve('a'), path.resolve('a'));
+      assert.equal(resolve('a'), unixify(path.resolve('a')));
     });
 
     it('should make a glob absolute', function () {
-      assert.equal(resolve('a/*.js'), path.resolve('a/*.js'));
+      assert.equal(resolve('a/*.js'), unixify(path.resolve('a/*.js')));
     });
 
     it('should retain trailing slashes', function () {
       actual = resolve('a/*/');
-      assert.equal(actual, path.resolve('a/*') + '/');
+      assert.equal(actual, unixify(path.resolve('a/*')) + '/');
       assert.equal(actual.slice(-1), '/');
     });
 
     it('should retain trailing slashes with cwd', function () {
-      fixture = './fixtures/whatsgoingon/*/';
+      fixture = 'fixtures/whatsgoingon/*/';
       actual = resolve(fixture, {cwd: __dirname});
-      assert.equal(actual, path.resolve(fixture) + '/');
+      assert.equal(actual, unixify(path.resolve(fixture)) + '/');
       assert.equal(actual.slice(-1), '/');
     });
 
     it('should make a negative glob absolute', function () {
       actual = resolve('!a/*.js');
-      assert.equal(actual, '!' + path.resolve('a/*.js'));
+      assert.equal(actual, '!' + unixify(path.resolve('a/*.js')));
     });
 
     it('should make a negative extglob absolute', function () {
       actual = resolve('!(foo)');
-      assert.equal(actual, path.resolve('!(foo)'));
+      assert.equal(actual, unixify(path.resolve('!(foo)')));
     });
 
     it('should make an escaped negative extglob absolute', function () {
       actual = resolve('\\!(foo)');
-      assert.equal(actual, path.resolve('\\!(foo)'));
+      assert.equal(actual, unixify(path.resolve('.')) + '/\\!(foo)');
     });
 
     it('should make a glob absolute from a cwd', function () {
       actual = resolve('a/*.js', {cwd: 'foo'});
-      assert.equal(actual, path.resolve('foo/a/*.js'));
+      assert.equal(actual, unixify(path.resolve('foo/a/*.js')));
     });
 
     it('should make a negative glob absolute from a cwd', function () {
       actual = resolve('!a/*.js', {cwd: 'foo'});
-      assert.equal(actual, '!' + path.resolve('foo/a/*.js'));
+      assert.equal(actual, '!' + unixify(path.resolve('foo/a/*.js')));
     });
 
     it('should make a glob absolute from a root path', function () {
       actual = resolve('/a/*.js', {root: 'foo'});
-      assert.equal(actual, path.resolve('foo/a/*.js'));
+      assert.equal(actual, unixify(path.resolve('foo/a/*.js')));
     });
 
     it('should make a glob absolute from a root slash', function () {
       actual = resolve('/a/*.js', {root: '/'});
-      assert.equal(actual, path.resolve('/a/*.js'));
+      assert.equal(actual, unixify(path.resolve('/a/*.js')));
     });
 
     it('should make a glob absolute from a negative root path', function () {
       actual = resolve('!/a/*.js', {root: 'foo'});
-      assert.equal(actual, '!' + path.resolve('foo/a/*.js'));
+      assert.equal(actual, '!' + unixify(path.resolve('foo/a/*.js')));
     });
 
     it('should make a negative glob absolute from a negative root path', function () {
       actual = resolve('!/a/*.js', {root: '/'})
-      assert.equal(actual, '!' + path.resolve('/a/*.js'));
+      assert.equal(actual, '!' + unixify(path.resolve('/a/*.js')));
     });
   });
 
   describe('windows', function () {
     it('should make an escaped negative extglob absolute', function () {
       actual = resolve('foo/bar\\!(baz)', {unixify: true});
-      assert.equal(actual, path.resolve('foo/bar\\!(baz)'));
+      assert.equal(actual, unixify(path.resolve('foo/bar')) + '\\!(baz)');
     });
 
     it('should make a glob absolute from a root path', function () {
       actual = resolve('/a/*.js', {root: 'foo\\bar\\baz', unixify: true});
-      assert.equal(actual, path.resolve('foo/bar/baz/a/*.js'));
+      assert.equal(actual, unixify(path.resolve('foo/bar/baz/a/*.js')));
     });
 
     it('should make a glob absolute from a root slash', function () {
       actual = resolve('/a/*.js', {root: '\\\\', unixify: true});
-      assert.equal(actual, path.resolve('/a/*.js'));
+      assert.equal(actual, unixify(path.resolve('/a/*.js')));
     });
   });
 });


### PR DESCRIPTION
@jonschlinkert @phated

After reviewing the comments in #7 and seeing the changes that @phated made in the `glob-stream` tests I made some updates and ran them on my windows vm and on my osx machine.

What I think this should be doing (from the previous comments) is always unixify parts that we know are file paths (these are `cwd` and `root`) and leave the glob parts as is. By doing this and adding a custom `join` function, I was able to get all of the tests to pass except one.

The test that's not passing has a `./` at the beginning of the glob pattern and was handled by the `path.resolve(cwd, glob)` that was previously in the code. I removed the `./` from the pattern since the test was for testing that the trailing `/` was still on the results, but I added a new skipped test with the `./` so we can discuss.

I also updated all the expected values in the tests to be unixified since this looks like what the expected results should be (this finally clicked for me after seeing the tests in glob-stream). I think this is acceptable because this library is turning a glob pattern into an absolute glob pattern and there should not be `\\` characters unless they are used for escaping.

I think we can support `./` at the beginning of glob patterns, but it gets more complicated if we want to be able to support `./` and `../` in the middle of glob patterns. AFAIK dots can be used in glob patterns in certain places, so I'm not sure exactly what should be supported here.

Let me know how this looks and if I missed something completely. I did this as a PR to the `is-absolute` branch so it should update the other PR if we merge it in.
