### PR TITLE
fix: Resolve ../ at the beginning of globs

### DIFF
--- a/index.js
+++ b/index.js
@@ -80,5 +80,12 @@ function join(dir, glob) {
     glob = glob.slice(1);
   }
   if (!glob) return dir;
+
+  // Resolve `../` segements in the  glob
+  while (glob.slice(0, 3) === '../') {
+    dir = dir.slice(0, dir.lastIndexOf('/'));
+    glob = glob.slice(3);
+  }
+
   return dir + '/' + glob;
 }

--- a/index.js
+++ b/index.js
@@ -25,6 +25,13 @@ module.exports = function(glob, options) {
     rootDir = escape(rootDir);
   }
 
+  // store last character before glob is modified
+  var suffix = glob.slice(-1);
+
+  // check to see if glob is negated (and not a leading negated-extglob)
+  var ing = isNegated(glob);
+  glob = ing.pattern;
+
   // trim starting ./ from glob patterns
   if (glob.slice(0, 2) === './') {
     glob = glob.slice(2);
@@ -34,13 +41,6 @@ module.exports = function(glob, options) {
   if (glob.length === 1 && glob === '.') {
     glob = '';
   }
-
-  // store last character before glob is modified
-  var suffix = glob.slice(-1);
-
-  // check to see if glob is negated (and not a leading negated-extglob)
-  var ing = isNegated(glob);
-  glob = ing.pattern;
 
   // make glob absolute
   if (rootDir && glob.charAt(0) === '/') {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "devDependencies": {
     "gulp-format-md": "^2.0.0",
-    "mocha": "^10.1.0"
+    "mocha": "^3.0.2"
   },
   "keywords": [
     "absolute",

--- a/test.js
+++ b/test.js
@@ -40,6 +40,18 @@ describe('resolve', function() {
       assert.equal(actual, unixify(path.resolve(fixture)) + '/');
     });
 
+    it('should handle ../ at the beginnnig of a glob', function() {
+      fixture = '../fixtures/whatsgoingon/*/';
+      actual = resolve(fixture, {cwd: __dirname});
+      assert.equal(actual, unixify(path.resolve(fixture)) + '/');
+    });
+
+    it('should handle multiple ../ at the beginnnig of a glob', function() {
+      fixture = '../../fixtures/whatsgoingon/*/';
+      actual = resolve(fixture, {cwd: __dirname});
+      assert.equal(actual, unixify(path.resolve(fixture)) + '/');
+    });
+
     it('should make a negative glob absolute', function() {
       actual = resolve('!a/*.js');
       assert.equal(actual, '!' + unixify(path.resolve('a/*.js')));
@@ -58,6 +70,16 @@ describe('resolve', function() {
     it('should make a negative glob (just `.`) absolute', function() {
       actual = resolve('!.');
       assert.equal(actual, '!' + unixify(path.resolve('.')));
+    });
+
+    it('should make a negative glob (starting with ../) absolute', function() {
+      actual = resolve('!../fixtures/whatsgoingon/*/');
+      assert.equal(actual, '!' + unixify(path.resolve('../fixtures/whatsgoingon/*/')) + '/');
+    });
+
+    it('should make a negative glob (starting with multiple ../) absolute', function() {
+      actual = resolve('!../../fixtures/whatsgoingon/*/');
+      assert.equal(actual, '!' + unixify(path.resolve('../../fixtures/whatsgoingon/*/')) + '/');
     });
 
     it('should make a negative extglob absolute', function() {

--- a/test.js
+++ b/test.js
@@ -45,6 +45,21 @@ describe('resolve', function() {
       assert.equal(actual, '!' + unixify(path.resolve('a/*.js')));
     });
 
+    it('should make a negative glob (starting with `./`) absolute', function() {
+      actual = resolve('!./a/*.js');
+      assert.equal(actual, '!' + unixify(path.resolve('a/*.js')));
+    });
+
+    it('should make a negative glob (just `./`) absolute', function() {
+      actual = resolve('!./');
+      assert.equal(actual, '!' + unixify(path.resolve('.')) + '/');
+    });
+
+    it('should make a negative glob (just `.`) absolute', function() {
+      actual = resolve('!.');
+      assert.equal(actual, '!' + unixify(path.resolve('.')));
+    });
+
     it('should make a negative extglob absolute', function() {
       actual = resolve('!(foo)');
       assert.equal(actual, unixify(path.resolve('!(foo)')));


### PR DESCRIPTION
This builds upon my changes in #21 and ensures support for any number of `../` at the beginning of a glob.

Since I had just resolved the escape characters and the `./` issue, it was apparent to me as I was managing the gulp 5 backlog that these issues would also need to be resolvedin `to-absolute-glob`: https://github.com/gulpjs/gulp/issues/2211, https://github.com/gulpjs/vinyl-fs/issues/312, and https://github.com/gulpjs/vinyl-fs/issues/306